### PR TITLE
Fix position of file upload fields on Message Template edit

### DIFF
--- a/templates/CRM/Templateattachments/Form/Admin.tpl
+++ b/templates/CRM/Templateattachments/Form/Admin.tpl
@@ -59,7 +59,7 @@
 {literal}
 <script type="text/javascript">
     CRM.$(function($) {
-        $('.crm-accordion-wrapper.crm-plaint_text_email-accordion').after($('#templateattachments_wrapper'));
+        $('#templateattachments_wrapper').insertBefore($('#message_templates #pdf_format'));
 
         var $form = $("form.CRM_Admin_Form_MessageTemplates");
         $form


### PR DESCRIPTION
Somewhere around CiviCRM 5.70, the HTML markup for accordions changed, and I think this broke this extension. Since the file fields are outside the "form" in the DOM, the file upload does not work.

Before:

![image](https://github.com/user-attachments/assets/cb171d32-4ca0-43e5-99be-6d512bdcdf72)

After:

![image](https://github.com/user-attachments/assets/2bfb2d19-0aec-4a85-a054-07e512ee631c)

I tested on CiviCRM 5.73+ with WordPress.

cc @jaapjansma 