### PR TITLE
Message Templates are mangled by purification since 5.72

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -302,4 +302,12 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
     }
   }
 
+  /**
+   * Override
+   * @return array
+   */
+  protected function getFieldsToExcludeFromPurification(): array {
+    return ['msg_html'];
+  }
+
 }


### PR DESCRIPTION
port of https://github.com/civicrm/civicrm-core/pull/30081/files

1. Open a system message template for editing.
2. Some of the code appears to be missing because it's been removed by purifier. And then when you save it breaks the template.