### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Admin/Form/MessageTemplates.php
+++ b/CRM/Admin/Form/MessageTemplates.php
@@ -105,7 +105,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
       );
     }
     else {
-      $this->_workflow_id = CRM_Utils_Array::value('workflow_id', $this->_values);
+      $this->_workflow_id = $this->_values['workflow_id'] ?? NULL;
       $this->assign('workflow_id', $this->_workflow_id);
 
       if ($this->_workflow_id) {
@@ -281,7 +281,7 @@ class CRM_Admin_Form_MessageTemplates extends CRM_Admin_Form {
         }
       }*/
 
-      $this->_workflow_id = CRM_Utils_Array::value('workflow_id', $this->_values);
+      $this->_workflow_id = $this->_values['workflow_id'] ?? NULL;
       if ($this->_workflow_id) {
         $params['workflow_id'] = $this->_workflow_id;
         $params['is_active'] = TRUE;


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.